### PR TITLE
Mention pyinstaller support in deploy doc

### DIFF
--- a/deploy.rst
+++ b/deploy.rst
@@ -45,3 +45,8 @@ Example Deployments
   MSYS2 and Inno Setup. It uses SCons for building/installing the application.
 
 * ...?
+
+Other options
+-------------
+
+* `PyInstaller <http://www.pyinstaller.org/>`_ is a program that freezes (packages) Python programs into stand-alone executables, under Windows, Linux, Mac OS X, and more. PyInstaller's packager has built-in support for automatically including PyGObject dependencies with your application without requiring additional configuration.


### PR DESCRIPTION
* Fixes #3 

I didn't link to an example because in theory you should be able to say 'pyinstaller foo.py', and the resulting exe in the `dist` folder should contain all of the necessary PyGObject dependencies. I suppose I could add that sentence to the description -- but, that's a detail of using pyinstaller, so I didn't think it fit. Your call.