### PR TITLE
Use destroy signal, not delete-event

### DIFF
--- a/getting_started.rst
+++ b/getting_started.rst
@@ -19,7 +19,7 @@ the following content and save it somewhere:
 
     window = Gtk.Window(title="Hello World")
     window.show()
-    window.connect("delete-event", Gtk.main_quit)
+    window.connect("destroy", Gtk.main_quit)
     Gtk.main()
 
 Before we can run the example application we need to install PyGObject, GTK+


### PR DESCRIPTION
It's confusing for users what the delete-event is. It's of use only if you want to perform some actions like displaying a dialog to save unsaved documents, or confirmation dialog. Semantically, reacting to the real destruction of the window, and hence of the main application window should be handled in the destroy signal, and its name is easier to remember.