### PR TITLE
Use destroy signal, not delete-event (last occurences)

### DIFF
--- a/guide/threading.rst
+++ b/guide/threading.rst
@@ -37,7 +37,7 @@ while still showing feedback on the progress in a window.
 
     def app_main():
         win = Gtk.Window(default_height=50, default_width=300)
-        win.connect("delete-event", Gtk.main_quit)
+        win.connect("destroy", Gtk.main_quit)
 
         progress = Gtk.ProgressBar(show_text=True)
         win.add(progress)
@@ -234,7 +234,7 @@ operation.
     if __name__ == "__main__":
         win = DownloadWindow()
         win.show_all()
-        win.connect("delete-event", Gtk.main_quit)
+        win.connect("destroy", Gtk.main_quit)
 
         Gtk.main()
 


### PR DESCRIPTION
It's confusing for users what the delete-event is. It's of use only if
you want to perform some actions like displaying a dialog to save
unsaved documents, or confirmation dialog. Semantically, reacting to the
real destruction of the window, and hence of the main application window
should be handled in the destroy signal, and its name is easier to
remember.